### PR TITLE
修复MQTT客户端BUG

### DIFF
--- a/iotkit-embedded/src/mqtt/Link-MQTT/mqtt_client.c
+++ b/iotkit-embedded/src/mqtt/Link-MQTT/mqtt_client.c
@@ -325,6 +325,7 @@ static int MQTTSubscribe(iotx_mc_client_t *c, const char *topicFilter, iotx_mqtt
                          iotx_mqtt_event_handle_func_fpt messageHandler, void *pcontext)
 {
     int len = 0;
+    int qos_sub = (int)qos;
     iotx_time_t timer;
     MQTTString topic = MQTTString_initializer;
     iotx_mc_topic_handle_t handler = {topicFilter, {messageHandler, pcontext}};
@@ -342,7 +343,7 @@ static int MQTTSubscribe(iotx_mc_client_t *c, const char *topicFilter, iotx_mqtt
     HAL_MutexLock(c->lock_write_buf);
 
     len = MQTTSerialize_subscribe((unsigned char *)c->buf_send, c->buf_size_send, 0, (unsigned short)msgId, 1, &topic,
-                                  (int *)&qos);
+                                  (int *)&qos_sub);
     if (len <= 0) {
         HAL_MutexUnlock(c->lock_write_buf);
         return MQTT_SUBSCRIBE_PACKET_ERROR;

--- a/samples/mqtt/mqtt-example.c
+++ b/samples/mqtt/mqtt-example.c
@@ -115,12 +115,13 @@ static char* rt_strlwr(char *str)
 static void event_handle(void *pcontext, void *pclient, iotx_mqtt_event_msg_pt msg)
 {
     iotx_mqtt_topic_info_pt topic_info = (iotx_mqtt_topic_info_pt)msg->msg;
+    uintptr_t packet_id = (uintptr_t)(msg->msg);
+
     if (topic_info == NULL)
     {
         rt_kprintf("Topic info is null! Exit.");
         return;
     }
-    uintptr_t packet_id = (uintptr_t)topic_info->packet_id;
 
     switch (msg->event_type) {
         case IOTX_MQTT_EVENT_UNDEF:


### PR DESCRIPTION
1. 枚举类型与int类型指针不能强转。
2. 传参与用参规则必须一致。