### PR TITLE
修正HAL_TCP_Destroy()中, 规避close(0)将console的rx_indicate清除

### DIFF
--- a/ports/rtthread/HAL_TCP_rtthread.c
+++ b/ports/rtthread/HAL_TCP_rtthread.c
@@ -113,6 +113,14 @@ uintptr_t HAL_TCP_Establish(const char *host, uint16_t port)
 int32_t HAL_TCP_Destroy(uintptr_t fd)
 {
     int rc;
+	
+#if defined(RT_USING_DFS_DEVFS) && defined(RT_USING_POSIX)
+    if ((0 <= (int)fd) && ((int)fd <= 2))
+    {
+        LOG_I("the FD of user can not less than 2 in rt-thread OS, Please see fd_get() in dfs.c.");
+        return 0;
+    }
+#endif
 
     rc = close((int) fd);
     if (0 != rc) {

--- a/ports/rtthread/HAL_TCP_rtthread.c
+++ b/ports/rtthread/HAL_TCP_rtthread.c
@@ -114,15 +114,7 @@ int32_t HAL_TCP_Destroy(uintptr_t fd)
 {
     int rc;
 	
-#if defined(RT_USING_DFS_DEVFS) && defined(RT_USING_POSIX)
-    if ((0 <= (int)fd) && ((int)fd <= 2))
-    {
-        LOG_I("the FD of user can not less than 2 in rt-thread OS, Please see fd_get() in dfs.c.");
-        return 0;
-    }
-#endif
-
-    rc = close((int) fd);
+    rc = closesocket((int) fd);
     if (0 != rc) {
         LOG_E("closesocket error");
         return -1;


### PR DESCRIPTION
在使能RT_USING_DFS_DEVFS和RT_USING_POSIX情况下，由于RTT预留了FD=0,1,2给stdio_console设备，当HAL_TCP_Destroy(uintptr_t fd)传入的fd为0时，会造成当前console设备的.rx_indicate被清除，从而造成FINSH无法接收输入。
