### PR TITLE
修改改FOTA在COTA之后MD5校验失败错误

### DIFF
--- a/iotkit-embedded/src/ota/iotx_ota.c
+++ b/iotkit-embedded/src/ota/iotx_ota.c
@@ -134,16 +134,18 @@ static int ota_callback(void *pcontext, const char *msg, uint32_t msg_len, iotx_
 
             h_ota->type = IOT_OTAT_FOTA;
             h_ota->state = IOT_OTAS_FETCHING;
-// TODO:modify by spunky
-			if (NULL != h_ota->md5) {
-                otalib_MD5Deinit(h_ota->md5);
-	        }
-	        h_ota->md5 = otalib_MD5Init();
 
-	        if (NULL != h_ota->sha256) {
-                otalib_Sha256Deinit(h_ota->sha256);
-	        }
-	        h_ota->sha256 = otalib_Sha256Init();				
+			if (NULL != h_ota->md5) 
+			{
+				otalib_MD5Deinit(h_ota->md5);
+			}
+			h_ota->md5 = otalib_MD5Init();
+
+			if (NULL != h_ota->sha256) 
+			{
+				otalib_Sha256Deinit(h_ota->sha256);
+			}
+			h_ota->sha256 = otalib_Sha256Init();				
 
             if (h_ota->fetch_cb) {
                 h_ota->fetch_cb(h_ota->user_data, 0, h_ota->size_file, h_ota->purl, h_ota->version);

--- a/iotkit-embedded/src/ota/iotx_ota.c
+++ b/iotkit-embedded/src/ota/iotx_ota.c
@@ -135,16 +135,16 @@ static int ota_callback(void *pcontext, const char *msg, uint32_t msg_len, iotx_
             h_ota->type = IOT_OTAT_FOTA;
             h_ota->state = IOT_OTAS_FETCHING;
 
-			if (NULL != h_ota->md5) 
-			{
-				otalib_MD5Deinit(h_ota->md5);
-			}
-			h_ota->md5 = otalib_MD5Init();
+            if (NULL != h_ota->md5)
+            {
+                otalib_MD5Deinit(h_ota->md5);
+            }
+            h_ota->md5 = otalib_MD5Init();
 
-			if (NULL != h_ota->sha256) 
-			{
-				otalib_Sha256Deinit(h_ota->sha256);
-			}
+            if (NULL != h_ota->sha256) 
+            {
+                otalib_Sha256Deinit(h_ota->sha256);
+            }
 			h_ota->sha256 = otalib_Sha256Init();				
 
             if (h_ota->fetch_cb) {

--- a/iotkit-embedded/src/ota/iotx_ota.c
+++ b/iotkit-embedded/src/ota/iotx_ota.c
@@ -145,7 +145,7 @@ static int ota_callback(void *pcontext, const char *msg, uint32_t msg_len, iotx_
             {
                 otalib_Sha256Deinit(h_ota->sha256);
             }
-			h_ota->sha256 = otalib_Sha256Init();				
+            h_ota->sha256 = otalib_Sha256Init();				
 
             if (h_ota->fetch_cb) {
                 h_ota->fetch_cb(h_ota->user_data, 0, h_ota->size_file, h_ota->purl, h_ota->version);

--- a/iotkit-embedded/src/ota/iotx_ota.c
+++ b/iotkit-embedded/src/ota/iotx_ota.c
@@ -134,6 +134,16 @@ static int ota_callback(void *pcontext, const char *msg, uint32_t msg_len, iotx_
 
             h_ota->type = IOT_OTAT_FOTA;
             h_ota->state = IOT_OTAS_FETCHING;
+// TODO:modify by spunky
+			if (NULL != h_ota->md5) {
+                otalib_MD5Deinit(h_ota->md5);
+	        }
+	        h_ota->md5 = otalib_MD5Init();
+
+	        if (NULL != h_ota->sha256) {
+                otalib_Sha256Deinit(h_ota->sha256);
+	        }
+	        h_ota->sha256 = otalib_Sha256Init();				
 
             if (h_ota->fetch_cb) {
                 h_ota->fetch_cb(h_ota->user_data, 0, h_ota->size_file, h_ota->purl, h_ota->version);


### PR DESCRIPTION
Linkkit高级接口时，发现在进行COTA功能后再使用FOTA功能，会造成MD5校验失败。经过调试发现是在启动FOTA时未进行MD5的初始化造成。已经验证修改有效。