### PR TITLE
[HUST CSE] fix if-statement to avoid null-pointer in  _mem_cmp_max_used

### DIFF
--- a/iotkit-embedded/src/infra/infra_mem_stats.c
+++ b/iotkit-embedded/src/infra/infra_mem_stats.c
@@ -83,7 +83,7 @@ static void _mem_swap_module_pos(list_head_t *a, list_head_t *b)
 {
     list_head_t temp = {NULL, NULL};
 
-    if (a == NULL) {
+    if (a == NULL || b == NULL) {
         return;
     }
 

--- a/iotkit-embedded/src/infra/infra_mem_stats.c
+++ b/iotkit-embedded/src/infra/infra_mem_stats.c
@@ -67,13 +67,13 @@ typedef struct {
 
 /* sort module used */
 static int _mem_cmp_max_used(list_head_t *a, list_head_t *b)
-{
-    module_mem_t *temp_a = list_entry(a, module_mem_t, list);
-    module_mem_t *temp_b = list_entry(b, module_mem_t, list);
-
+{   
     if (a == NULL || b == NULL) {
         return 0;
     }
+    
+    module_mem_t *temp_a = list_entry(a, module_mem_t, list);
+    module_mem_t *temp_b = list_entry(b, module_mem_t, list);
 
     /* return true to swap if a < b */
     return (temp_a->mem_statis.bytes_max_in_use < temp_b->mem_statis.bytes_max_in_use);
@@ -83,7 +83,7 @@ static void _mem_swap_module_pos(list_head_t *a, list_head_t *b)
 {
     list_head_t temp = {NULL, NULL};
 
-    if (a == NULL || a == NULL) {
+    if (a == NULL) {
         return;
     }
 


### PR DESCRIPTION
### 问题描述
在函数  __mem_cmp_max_used(list_head_t *a, list_head_t *b)_ 中, 传入的指针 **a** 和 **b** 有可能为空指针 , 此问题理应交由接下来的**if 判断语句**检查并解决 : _if (a == NULL || b == NULL) return 0;_
然而, if 判断语句**处于了错误的位置**, 使程序仍然处于空指针问题的风险中。

### 解决方案
**重新定位**  _if 判断语句至函数入口处, 在语句 ` module_mem_t *temp_a = list_entry(a, module_mem_t, list);
    module_mem_t *temp_b = list_entry(b, module_mem_t, list);` 使用a，b指针**之前**就先检查是否为空。


除此之外, 在函数 __mem_swap_module_pos_ 的 if 判断语句中存在一处明显的打字错误， `a == NULL || a == NULL` 应该是 `a == NULL || b == NULL`