### PR TITLE
[HUST CSE] fix mismatched parameter

### DIFF
--- a/iotkit-embedded/wrappers/os/ubuntu/HAL_OS_linux.c
+++ b/iotkit-embedded/wrappers/os/ubuntu/HAL_OS_linux.c
@@ -278,7 +278,7 @@ char *_get_default_routing_ifname(char *ifname, int ifname_size)
 
     while (fgets(line, sizeof(line), fp)) {
         if (11 !=
-            sscanf(line, "%s %08x %08x %x %d %d %d %08x %d %d %d",
+            sscanf(line, "%s %08x %08x %x %u %u %u %08x %u %u %u",
                    iface, &destination, &gateway, &flags, &refCnt, &use,
                    &metric, &mask, &mtu, &window, &irtt)) {
             perror("sscanf");


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

sscanf读入的参数类型不匹配，在函数中变量refCnt，use，metric，mtu，window，irtt都被定义为unsigned int类型，sscanf中的对应参数应该使用%u而非%d。

#### 你的解决方案是什么 (what is your solution)

将sscanf中的对应参数%d改为%u。
#### 在什么测试环境下测试通过 (what is the test environment)
只修改了输入的参数类型，在所有测试环境下都会测试通过。
]