### PR TITLE
[HUST CSE]【修改】memset函数中sizeof用法错误

### DIFF
--- a/iotkit-embedded/wrappers/tls/HAL_TLS_mbedtls.c
+++ b/iotkit-embedded/wrappers/tls/HAL_TLS_mbedtls.c
@@ -603,7 +603,7 @@ static int _TLSConnectNetwork(TLSDataParams_t *pTlsData, const char *addr, const
                 HAL_Free(save_buf);
                 break;
             }
-            memset(save_buf, 0x00, sizeof(TLS_MAX_SESSION_BUF));
+            memset(save_buf, 0x00, TLS_MAX_SESSION_BUF * sizeof(int));
             memset(saved_session, 0x00, sizeof(mbedtls_ssl_session));
 
             ret = mbedtls_ssl_get_session(&(pTlsData->ssl), saved_session);

--- a/iotkit-embedded/wrappers/tls/HAL_TLS_mbedtls.c
+++ b/iotkit-embedded/wrappers/tls/HAL_TLS_mbedtls.c
@@ -603,7 +603,7 @@ static int _TLSConnectNetwork(TLSDataParams_t *pTlsData, const char *addr, const
                 HAL_Free(save_buf);
                 break;
             }
-            memset(save_buf, 0x00, TLS_MAX_SESSION_BUF * sizeof(int));
+            memset(save_buf, 0x00, TLS_MAX_SESSION_BUF);
             memset(saved_session, 0x00, sizeof(mbedtls_ssl_session));
 
             ret = mbedtls_ssl_get_session(&(pTlsData->ssl), saved_session);


### PR DESCRIPTION
**问题描述**
在函数 memset(save_buf, 0x00, sizeof(TLS_MAX_SESSION_BUF)) 中, sizeof中参数TLS_MAX_SESSION_BUF为一已经宏定义的常量，其sizeof返回值不为将被置0的内存空间大小。

**解决方案**
将函数memset的第三个参数改为TLS_MAX_SESSION_BUF * sizeof(int)即可解决问题。